### PR TITLE
Add a tolerance parameter to 2dbitmap and 1dbitmap

### DIFF
--- a/util/bitmap.scad
+++ b/util/bitmap.scad
@@ -78,12 +78,14 @@ use <compat.scad>
  *          Value can either be boolean, z-height, or color
  * center - center cubes around the origin
  * expansion - size of gap around each pixel (screendoor)
+ * tolerance - amount to overlap so coincident bits merge
  * vector_mode - create a 2D vector drawing instead of 3D extrusion
  */
-module 2dbitmap(bitmap=[[1,0],[0,1]], center=false, expansion=0, vector_mode=false)
+module 2dbitmap(bitmap=[[1,0],[0,1]], center=false, expansion=0, tolerance=0.001, vector_mode=false)
 {
   if (bitmap!=undef) {
 	ylen=len(bitmap)-1;
+    adjustment=-expansion+tolerance;
 
 	for (y=[0:ylen]) {
 		xlen=len(bitmap[y])-1;
@@ -92,22 +94,22 @@ module 2dbitmap(bitmap=[[1,0],[0,1]], center=false, expansion=0, vector_mode=fal
 				if (is_indexable(bitmap[y][x]))
 					color(bitmap[y][x])
 						if (vector_mode)
-							square([1-expansion,1-expansion], center=center);
+							square([1+adjustment,1+adjustment], center=center);
 						else
-							cube([1-expansion,1-expansion,1], center=center);
+							cube([1+adjustment,1+adjustment,1], center=center);
 				else
 					if (bitmap[y][x])
 						if (vector_mode)
-							square([1-expansion,1-expansion], center=center);
+							square([1+adjustment,1+adjustment], center=center);
 						else
-							cube([1-expansion,1-expansion,clamp_nonnum(bitmap[y][x])], center=center);
+							cube([1+adjustment,1+adjustment,clamp_nonnum(bitmap[y][x])], center=center);
 	}
   }
 }
 
-module 1dbitmap(bitmap=[1,0,1,0,1], center=false, expansion=0, vector_mode=false)
+module 1dbitmap(bitmap=[1,0,1,0,1], center=false, expansion=0, tolerance=0.001, vector_mode=false)
 	if (bitmap!=undef)
-		2dbitmap([bitmap], center, expansion, vector_mode);
+		2dbitmap([bitmap], center, expansion, tolerance, vector_mode);
 
 /*
  * Examples


### PR DESCRIPTION
Since the bits are coincident it can leave non-manifold [artifacts](https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/FAQ#What_are_those_strange_flickering_artifacts_in_the_preview?) in models.

Before: 
![coincident](https://user-images.githubusercontent.com/1885701/126078409-a2e3e3a4-ebe8-49ff-94c0-b786793d39fa.png)

After:
![overlapping](https://user-images.githubusercontent.com/1885701/126078418-b61d7bd6-7424-4e7f-8cf6-8f48691e227b.png)